### PR TITLE
[130] Support for the Message Templates API

### DIFF
--- a/build.savant
+++ b/build.savant
@@ -15,7 +15,7 @@
  */
 savantVersion = "1.0.0"
 
-project(group: "io.fusionauth", name: "fusionauth-dart-client", version: "1.21.1", licenses: ["ApacheV2_0"]) {
+project(group: "io.fusionauth", name: "fusionauth-dart-client", version: "1.22.0", licenses: ["ApacheV2_0"]) {
   workflow {
     standard()
   }

--- a/build.savant
+++ b/build.savant
@@ -15,7 +15,7 @@
  */
 savantVersion = "1.0.0"
 
-project(group: "io.fusionauth", name: "fusionauth-dart-client", version: "1.22.0", licenses: ["ApacheV2_0"]) {
+project(group: "io.fusionauth", name: "fusionauth-dart-client", version: "1.23.0", licenses: ["ApacheV2_0"]) {
   workflow {
     standard()
   }

--- a/lib/src/FusionAuthClient.dart
+++ b/lib/src/FusionAuthClient.dart
@@ -346,6 +346,21 @@ class FusionAuthClient {
         .go();
   }
 
+  /// Creates an message template. You can optionally specify an Id for the template, if not provided one will be generated.
+  ///
+  /// @param {String} messageTemplateId (Optional) The Id for the template. If not provided a secure random UUID will be generated.
+  /// @param {MessageTemplateRequest} request The request object that contains all of the information used to create the message template.
+  /// @returns {Promise<ClientResponse<MessageTemplateResponse>>}
+  Future<ClientResponse<MessageTemplateResponse, Errors>> createMessageTemplate(String messageTemplateId, MessageTemplateRequest request) {
+    return _start<MessageTemplateResponse, Errors>()
+        .withUri('/api/message/template')
+        .withUriSegment(messageTemplateId)
+        .withJSONBody(request)
+        .withMethod('POST')
+        .withResponseHandler(defaultResponseHandlerBuilder((d) => MessageTemplateResponse.fromJson(d)))
+        .go();
+  }
+
   /// Creates a tenant. You can optionally specify an Id for the tenant, if not provided one will be generated.
   ///
   /// @param {String} tenantId (Optional) The Id for the tenant. If not provided a secure random UUID will be generated.
@@ -669,6 +684,18 @@ class FusionAuthClient {
     return _start<void, Errors>()
         .withUri('/api/lambda')
         .withUriSegment(lambdaId)
+        .withMethod('DELETE')
+        .go();
+  }
+
+  /// Deletes the message template for the given Id.
+  ///
+  /// @param {String} messageTemplateId The Id of the message template to delete.
+  /// @returns {Promise<ClientResponse<void>>}
+  Future<ClientResponse<void, Errors>> deleteMessageTemplate(String messageTemplateId) {
+    return _start<void, Errors>()
+        .withUri('/api/message/template')
+        .withUriSegment(messageTemplateId)
         .withMethod('DELETE')
         .go();
   }
@@ -1366,6 +1393,21 @@ class FusionAuthClient {
         .withJSONBody(request)
         .withMethod('PATCH')
         .withResponseHandler(defaultResponseHandlerBuilder((d) => LambdaResponse.fromJson(d)))
+        .go();
+  }
+
+  /// Updates, via PATCH, the message template with the given Id.
+  ///
+  /// @param {String} messageTemplateId The Id of the message template to update.
+  /// @param {MessageTemplateRequest} request The request that contains just the new message template information.
+  /// @returns {Promise<ClientResponse<MessageTemplateResponse>>}
+  Future<ClientResponse<MessageTemplateResponse, Errors>> patchMessageTemplate(String messageTemplateId, MessageTemplateRequest request) {
+    return _start<MessageTemplateResponse, Errors>()
+        .withUri('/api/message/template')
+        .withUriSegment(messageTemplateId)
+        .withJSONBody(request)
+        .withMethod('PATCH')
+        .withResponseHandler(defaultResponseHandlerBuilder((d) => MessageTemplateResponse.fromJson(d)))
         .go();
   }
 
@@ -2139,6 +2181,30 @@ class FusionAuthClient {
         .withParameter('end', end)
         .withMethod('GET')
         .withResponseHandler(defaultResponseHandlerBuilder((d) => LoginReportResponse.fromJson(d)))
+        .go();
+  }
+
+  /// Retrieves the message template for the given Id. If you don't specify the id, this will return all of the message templates.
+  ///
+  /// @param {String} messageTemplateId (Optional) The Id of the message template.
+  /// @returns {Promise<ClientResponse<MessageTemplateResponse>>}
+  Future<ClientResponse<MessageTemplateResponse, void>> retrieveMessageTemplate(String messageTemplateId) {
+    return _start<MessageTemplateResponse, void>()
+        .withUri('/api/message/template')
+        .withUriSegment(messageTemplateId)
+        .withMethod('GET')
+        .withResponseHandler(defaultResponseHandlerBuilder((d) => MessageTemplateResponse.fromJson(d)))
+        .go();
+  }
+
+  /// Retrieves all of the message templates.
+  ///
+  /// @returns {Promise<ClientResponse<MessageTemplateResponse>>}
+  Future<ClientResponse<MessageTemplateResponse, void>> retrieveMessageTemplates() {
+    return _start<MessageTemplateResponse, void>()
+        .withUri('/api/message/template')
+        .withMethod('GET')
+        .withResponseHandler(defaultResponseHandlerBuilder((d) => MessageTemplateResponse.fromJson(d)))
         .go();
   }
 
@@ -3045,6 +3111,21 @@ class FusionAuthClient {
         .withJSONBody(request)
         .withMethod('PUT')
         .withResponseHandler(defaultResponseHandlerBuilder((d) => LambdaResponse.fromJson(d)))
+        .go();
+  }
+
+  /// Updates the message template with the given Id.
+  ///
+  /// @param {String} messageTemplateId The Id of the message template to update.
+  /// @param {MessageTemplateRequest} request The request that contains all of the new message template information.
+  /// @returns {Promise<ClientResponse<MessageTemplateResponse>>}
+  Future<ClientResponse<MessageTemplateResponse, Errors>> updateMessageTemplate(String messageTemplateId, MessageTemplateRequest request) {
+    return _start<MessageTemplateResponse, Errors>()
+        .withUri('/api/message/template')
+        .withUriSegment(messageTemplateId)
+        .withJSONBody(request)
+        .withMethod('PUT')
+        .withResponseHandler(defaultResponseHandlerBuilder((d) => MessageTemplateResponse.fromJson(d)))
         .go();
   }
 

--- a/lib/src/FusionAuthClient.dart
+++ b/lib/src/FusionAuthClient.dart
@@ -2197,6 +2197,19 @@ class FusionAuthClient {
         .go();
   }
 
+  /// Creates a preview of the message template provided in the request, normalized to a given locale.
+  ///
+  /// @param {PreviewMessageTemplateRequest} request The request that contains the email template and optionally a locale to render it in.
+  /// @returns {Promise<ClientResponse<PreviewMessageTemplateResponse>>}
+  Future<ClientResponse<PreviewMessageTemplateResponse, Errors>> retrieveMessageTemplatePreview(PreviewMessageTemplateRequest request) {
+    return _start<PreviewMessageTemplateResponse, Errors>()
+        .withUri('/api/message/template/preview')
+        .withJSONBody(request)
+        .withMethod('POST')
+        .withResponseHandler(defaultResponseHandlerBuilder((d) => PreviewMessageTemplateResponse.fromJson(d)))
+        .go();
+  }
+
   /// Retrieves all of the message templates.
   ///
   /// @returns {Promise<ClientResponse<MessageTemplateResponse>>}

--- a/lib/src/FusionAuthDomain.dart
+++ b/lib/src/FusionAuthDomain.dart
@@ -3395,6 +3395,21 @@ class MemberResponse {
   Map<String, dynamic> toJson() => _$MemberResponseToJson(this);
 }
 
+/// An incredible simplified view of a message
+///
+/// @author Michael Sleevi
+@JsonSerializable()
+class Message {
+  String text;
+
+  Message({
+      this.text
+  });
+
+  factory Message.fromJson(Map<String, dynamic> json) => _$MessageFromJson(json);
+  Map<String, dynamic> toJson() => _$MessageToJson(this);
+}
+
 /// Stores an message template used to distribute messages;
 ///
 /// @author Michael Sleevi
@@ -3970,6 +3985,35 @@ class PendingResponse {
 
   factory PendingResponse.fromJson(Map<String, dynamic> json) => _$PendingResponseFromJson(json);
   Map<String, dynamic> toJson() => _$PendingResponseToJson(this);
+}
+
+/// @author Michael Sleevi
+@JsonSerializable()
+class PreviewMessageTemplateRequest {
+  String locale;
+  MessageTemplate messageTemplate;
+
+  PreviewMessageTemplateRequest({
+      this.locale,
+      this.messageTemplate
+  });
+
+  factory PreviewMessageTemplateRequest.fromJson(Map<String, dynamic> json) => _$PreviewMessageTemplateRequestFromJson(json);
+  Map<String, dynamic> toJson() => _$PreviewMessageTemplateRequestToJson(this);
+}
+
+@JsonSerializable()
+class PreviewMessageTemplateResponse {
+  Errors errors;
+  Message message;
+
+  PreviewMessageTemplateResponse({
+      this.errors,
+      this.message
+  });
+
+  factory PreviewMessageTemplateResponse.fromJson(Map<String, dynamic> json) => _$PreviewMessageTemplateResponseFromJson(json);
+  Map<String, dynamic> toJson() => _$PreviewMessageTemplateResponseToJson(this);
 }
 
 /// @author Brian Pontarelli

--- a/lib/src/FusionAuthDomain.dart
+++ b/lib/src/FusionAuthDomain.dart
@@ -3395,6 +3395,60 @@ class MemberResponse {
   Map<String, dynamic> toJson() => _$MemberResponseToJson(this);
 }
 
+/// Stores an message template used to distribute messages;
+///
+/// @author Michael Sleevi
+@JsonSerializable()
+class MessageTemplate {
+  String defaultTemplate;
+  String id;
+  num insertInstant;
+  num lastUpdateInstant;
+  Map<String, String> localizedTemplates;
+  String name;
+
+  MessageTemplate({
+      this.defaultTemplate,
+      this.id,
+      this.insertInstant,
+      this.lastUpdateInstant,
+      this.localizedTemplates,
+      this.name
+  });
+
+  factory MessageTemplate.fromJson(Map<String, dynamic> json) => _$MessageTemplateFromJson(json);
+  Map<String, dynamic> toJson() => _$MessageTemplateToJson(this);
+}
+
+/// A Message Template Request to the API
+///
+/// @author Michael Sleevi
+@JsonSerializable()
+class MessageTemplateRequest {
+  MessageTemplate messageTemplate;
+
+  MessageTemplateRequest({
+      this.messageTemplate
+  });
+
+  factory MessageTemplateRequest.fromJson(Map<String, dynamic> json) => _$MessageTemplateRequestFromJson(json);
+  Map<String, dynamic> toJson() => _$MessageTemplateRequestToJson(this);
+}
+
+@JsonSerializable()
+class MessageTemplateResponse {
+  MessageTemplate messageTemplate;
+  List<MessageTemplate> messageTemplates;
+
+  MessageTemplateResponse({
+      this.messageTemplate,
+      this.messageTemplates
+  });
+
+  factory MessageTemplateResponse.fromJson(Map<String, dynamic> json) => _$MessageTemplateResponseFromJson(json);
+  Map<String, dynamic> toJson() => _$MessageTemplateResponseToJson(this);
+}
+
 @JsonSerializable()
 class MetaData {
   DeviceInfo device;

--- a/lib/src/FusionAuthDomain.g.dart
+++ b/lib/src/FusionAuthDomain.g.dart
@@ -4710,6 +4710,25 @@ Map<String, dynamic> _$MemberResponseToJson(MemberResponse instance) {
   return val;
 }
 
+Message _$MessageFromJson(Map<String, dynamic> json) {
+  return Message(
+    text: json['text'] as String,
+  );
+}
+
+Map<String, dynamic> _$MessageToJson(Message instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('text', instance.text);
+  return val;
+}
+
 MessageTemplate _$MessageTemplateFromJson(Map<String, dynamic> json) {
   return MessageTemplate(
     defaultTemplate: json['defaultTemplate'] as String,
@@ -5535,6 +5554,59 @@ Map<String, dynamic> _$PendingResponseToJson(PendingResponse instance) {
   }
 
   writeNotNull('users', instance.users);
+  return val;
+}
+
+PreviewMessageTemplateRequest _$PreviewMessageTemplateRequestFromJson(
+    Map<String, dynamic> json) {
+  return PreviewMessageTemplateRequest(
+    locale: json['locale'] as String,
+    messageTemplate: json['messageTemplate'] == null
+        ? null
+        : MessageTemplate.fromJson(
+            json['messageTemplate'] as Map<String, dynamic>),
+  );
+}
+
+Map<String, dynamic> _$PreviewMessageTemplateRequestToJson(
+    PreviewMessageTemplateRequest instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('locale', instance.locale);
+  writeNotNull('messageTemplate', instance.messageTemplate);
+  return val;
+}
+
+PreviewMessageTemplateResponse _$PreviewMessageTemplateResponseFromJson(
+    Map<String, dynamic> json) {
+  return PreviewMessageTemplateResponse(
+    errors: json['errors'] == null
+        ? null
+        : Errors.fromJson(json['errors'] as Map<String, dynamic>),
+    message: json['message'] == null
+        ? null
+        : Message.fromJson(json['message'] as Map<String, dynamic>),
+  );
+}
+
+Map<String, dynamic> _$PreviewMessageTemplateResponseToJson(
+    PreviewMessageTemplateResponse instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('errors', instance.errors);
+  writeNotNull('message', instance.message);
   return val;
 }
 

--- a/lib/src/FusionAuthDomain.g.dart
+++ b/lib/src/FusionAuthDomain.g.dart
@@ -4710,6 +4710,92 @@ Map<String, dynamic> _$MemberResponseToJson(MemberResponse instance) {
   return val;
 }
 
+MessageTemplate _$MessageTemplateFromJson(Map<String, dynamic> json) {
+  return MessageTemplate(
+    defaultTemplate: json['defaultTemplate'] as String,
+    id: json['id'] as String,
+    insertInstant: json['insertInstant'] as num,
+    lastUpdateInstant: json['lastUpdateInstant'] as num,
+    localizedTemplates:
+        (json['localizedTemplates'] as Map<String, dynamic>)?.map(
+      (k, e) => MapEntry(k, e as String),
+    ),
+    name: json['name'] as String,
+  );
+}
+
+Map<String, dynamic> _$MessageTemplateToJson(MessageTemplate instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('defaultTemplate', instance.defaultTemplate);
+  writeNotNull('id', instance.id);
+  writeNotNull('insertInstant', instance.insertInstant);
+  writeNotNull('lastUpdateInstant', instance.lastUpdateInstant);
+  writeNotNull('localizedTemplates', instance.localizedTemplates);
+  writeNotNull('name', instance.name);
+  return val;
+}
+
+MessageTemplateRequest _$MessageTemplateRequestFromJson(
+    Map<String, dynamic> json) {
+  return MessageTemplateRequest(
+    messageTemplate: json['messageTemplate'] == null
+        ? null
+        : MessageTemplate.fromJson(
+            json['messageTemplate'] as Map<String, dynamic>),
+  );
+}
+
+Map<String, dynamic> _$MessageTemplateRequestToJson(
+    MessageTemplateRequest instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('messageTemplate', instance.messageTemplate);
+  return val;
+}
+
+MessageTemplateResponse _$MessageTemplateResponseFromJson(
+    Map<String, dynamic> json) {
+  return MessageTemplateResponse(
+    messageTemplate: json['messageTemplate'] == null
+        ? null
+        : MessageTemplate.fromJson(
+            json['messageTemplate'] as Map<String, dynamic>),
+    messageTemplates: (json['messageTemplates'] as List)
+        ?.map((e) => e == null
+            ? null
+            : MessageTemplate.fromJson(e as Map<String, dynamic>))
+        ?.toList(),
+  );
+}
+
+Map<String, dynamic> _$MessageTemplateResponseToJson(
+    MessageTemplateResponse instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('messageTemplate', instance.messageTemplate);
+  writeNotNull('messageTemplates', instance.messageTemplates);
+  return val;
+}
+
 MetaData _$MetaDataFromJson(Map<String, dynamic> json) {
   return MetaData(
     device: json['device'] == null

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fusionauth_dart_client
 description: A starting point for Dart libraries or applications.
-version: 1.21.1
+version: 1.22.0
 homepage: https://github.com/FusionAuth/fusionauth-dart-client
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fusionauth_dart_client
 description: A starting point for Dart libraries or applications.
-version: 1.22.0
+version: 1.23.0
 homepage: https://github.com/FusionAuth/fusionauth-dart-client
 
 environment:


### PR DESCRIPTION
Related Issues
----

* [130](https://github.com/FusionAuth/fusionauth-internal-issues/issues/130)

Background
-----

This PR incorporates the client changes for the support of enhanced MFA functionality.

Implementation Details
-----

* Adds new Message Template methods for interacting with the upcoming APIs, namely:
  * Supports PUT /api/message/template/{id}
  * Supports GET /api/message/template/{id}
  * Supports GET /api/message/template
  * Supports POST /api/message/template
  * Supports DELETE /api/message/template
  * Supports PATCH /api/message/template/{id}
  * Supports POST /api/message/template/preview
* Adds new Domain objects and responses for the upcoming APIs, namely:
  * `io.fusionauth.domain.api.MessageTemplateRequest`
  * `io.fusionauth.domain.api.MessageTemplateResponse`
  * `io.fusionauth.domain.api.PreviewMessageTemplateRequest`
  * `io.fusionauth.domain.api.PreviewMessageTemplateResponse`
  * `io.fusionauth.domain.message.MessageTemplate`
  * `io.fusionauth.domain.message.Message`