### PR TITLE
Fixes for various sb targets related to Dart and Go

### DIFF
--- a/build.savant
+++ b/build.savant
@@ -53,7 +53,6 @@ target(name: "format", description: "Formats the source code") {
   process.waitFor()
 }
 
-
 target(name: "setup", description: "Setup Dart build tools") {
   if (new ProcessBuilder('brew', 'tap', 'dart-lang/dart').inheritIO().start().waitFor() != 0) {
     fail('Failed to brew tap dart-lang/dart')


### PR DESCRIPTION
#### Sample `fusionauth-pr` body as create by a script:
Related PRs in this update:
- [fusionauth-app](https://github.com/FusionAuth/fusionauth-app/pull/39)
- [go-client](https://github.com/FusionAuth/go-client/pull/50)
- [fusionauth-client-builder](https://github.com/FusionAuth/fusionauth-client-builder/pull/30)

#### Some context of whats going on here
If we imagine there was a `fusionauth-pr` repo as part of the project then we could potentially script a command `is pr create` to create something like the above as a PR to `fusionauth-pr` with links to all the related PRs.  This PR here in `dart-client` got accidentally created, so I'm using it as an example of how things _might_ look.  There is a limitation of the `gh` command line interface to github.  You can `pr create --body-file filename` from a file (documented, but I have not tested it) and only edit with a `pr edit --body "New body for PR"`.  Which means (I think) you are limited in how big your edited body can be.  So, you create all the PRs for the various main/code repos and collect all the links to the those PRs.  Then, you create a PR in the `fusionauth-pr` repo with the body from a file that contains all the links (like the block above).  And last, you loop back through and `pr edit` all the bodies with links back to the main `fusionauth-pr` PR.  All that can be scripted.  So, the last part would be for the dev to edit the body of the `fusionauth-pr` PR with more details about the update they are trying to push.  For example the final body might look something like: 

#### Sample `fusionauth-pr` body as create/edited by the dev:
This combined PR changes various things related to the Dart and Go clients:
- In `fusionauth-client-builder` call `sb format` on the Dart and Go clients after building
- Add `setup` target to `go-client`
- In `fusionauth-app` add `go-client` to `testClientLibraries` list of libraries
- In `fusionauth-dart-client` removes a newline (oops, can probably close/delete this PR 😬)

Related PRs in this update:
- [fusionauth-app](https://github.com/FusionAuth/fusionauth-app/pull/39)
- [go-client](https://github.com/FusionAuth/go-client/pull/50)
- [fusionauth-client-builder](https://github.com/FusionAuth/fusionauth-client-builder/pull/30)
